### PR TITLE
No document

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Include a reference to the cookbook in a [Cheffile][cheffile] and run
     librarian-chef init
     cat >> Cheffile <<END_OF_CHEFFILE
     cookbook 'rvm',
-      :git => 'git://github.com/fnichol/chef-rvm.git', :ref => 'v0.10.1'
+      :git => 'git://github.com/fnichol/chef-rvm.git', :ref => 'v0.10.2'
     END_OF_CHEFFILE
     librarian-chef install
 

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -146,7 +146,7 @@ class Chef
           end
 
           cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
-          cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
+          cmd << %{ install #{name} -q --no-document -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
           if gem_env.user

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages system-wide and per-user RVMs and manages installed Rubies. Several lightweight resources and providers (LWRP) are also defined.Installs and manages RVM. Includes several LWRPs."
 long_description  "Please refer to README.md (it's long)."
-version           "0.10.1"
+version           "0.10.2"
 
 recipe "rvm",                 "Installs the RVM gem and initializes Chef to use the Lightweight Resources and Providers (LWRPs). Use this recipe explicitly if you only want access to the LWRPs provided."
 recipe "rvm::system_install", "Installs the RVM codebase system-wide (that is, into /usr/local/rvm). This recipe includes *default*. Use this recipe by itself if you want RVM installed system-wide but want to handle installing Rubies, invoking LWRPs, etc.."


### PR DESCRIPTION
Use the `--no-document` flag instead of `--no-ri --no-rdoc`.
They are disabled in rubygems 3 which automatically get installed by rvm
when installing new rubies